### PR TITLE
Fix the SSL and proxy issues (#10)

### DIFF
--- a/github_downloader.py
+++ b/github_downloader.py
@@ -25,12 +25,12 @@ class GitHubDownloader:
     """
     Downloads GitHub release assets with authentication and verification.
     """
-    
-    def __init__(self, token: str, download_dir: str = 'downloads', 
+
+    def __init__(self, token: str, download_dir: str = 'downloads',
                  chunk_size: int = 8192, timeout: int = 300):
         """
         Initialize GitHub downloader.
-        
+
         Args:
             token: GitHub API token
             download_dir: Directory to store downloaded files
@@ -41,10 +41,10 @@ class GitHubDownloader:
         self.download_dir = Path(download_dir)
         self.chunk_size = chunk_size
         self.timeout = timeout
-        
+
         # Create download directory
         self.download_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Setup session with authentication
         self.session = requests.Session()
         self.session.headers.update({
@@ -52,7 +52,18 @@ class GitHubDownloader:
             'Accept': 'application/vnd.github.v3+json',
             'User-Agent': 'GitHub-Release-Monitor-Downloader/1.0'
         })
-        
+
+        # Configure proxy settings from environment if present
+        proxy_settings = {}
+        if os.getenv('HTTP_PROXY') or os.getenv('http_proxy'):
+            proxy_settings['http'] = os.getenv('HTTP_PROXY') or os.getenv('http_proxy')
+        if os.getenv('HTTPS_PROXY') or os.getenv('https_proxy'):
+            proxy_settings['https'] = os.getenv('HTTPS_PROXY') or os.getenv('https_proxy')
+
+        if proxy_settings:
+            self.session.proxies = proxy_settings
+            logger.info(f"Configured proxy settings: {list(proxy_settings.keys())}")
+
         # Configure SSL verification
         skip_ssl_verification = os.environ.get('GITHUB_SKIP_SSL_VERIFICATION', 'false').lower() == 'true'
         if skip_ssl_verification:
@@ -61,76 +72,76 @@ class GitHubDownloader:
             # Suppress SSL warnings
             import urllib3
             urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-        
+
         logger.info(f"GitHub downloader initialized, download dir: {self.download_dir}")
-    
-    def download_release_content(self, release_data: Dict[str, Any], 
+
+    def download_release_content(self, release_data: Dict[str, Any],
                                asset_patterns: Optional[List[str]] = None,
                                source_config: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """
         Download all available content from a GitHub release (assets + source code).
-        
+
         Args:
             release_data: Release data from GitHub API or monitor
             asset_patterns: Optional list of patterns to filter content (e.g., ['*.tar.gz', '*.zip', '*.yaml'])
             source_config: Optional source archive configuration
-            
+
         Returns:
             List of download results with metadata
         """
         download_results = []
-        
+
         # Default source configuration
         if source_config is None:
             source_config = {'enabled': True, 'prefer': 'tarball', 'fallback_only': True}
-        
+
         # Download release assets (binaries, manifests, etc.)
         if release_data.get('assets'):
             asset_results = self.download_release_assets(release_data, asset_patterns)
             download_results.extend(asset_results)
-        
+
         # Download source code archives based on configuration
         if source_config.get('enabled', True) and self._should_download_source(release_data, asset_patterns, download_results, source_config):
             source_results = self.download_source_archives(release_data, asset_patterns, source_config)
             download_results.extend(source_results)
-        
+
         return download_results
-    
-    def download_release_assets(self, release_data: Dict[str, Any], 
+
+    def download_release_assets(self, release_data: Dict[str, Any],
                               asset_patterns: Optional[List[str]] = None) -> List[Dict[str, Any]]:
         """
         Download all or filtered assets from a GitHub release.
-        
+
         Args:
             release_data: Release data from GitHub API or monitor
             asset_patterns: Optional list of patterns to filter assets (e.g., ['*.tar.gz', '*.zip'])
-            
+
         Returns:
             List of download results with metadata
         """
         if not release_data.get('assets'):
             logger.warning(f"No assets found in release {release_data.get('tag_name', 'unknown')}")
             return []
-        
+
         # Create release-specific directory
         repo_name = release_data.get('repository', 'unknown').replace('/', '_')
         tag_name = release_data.get('tag_name', 'unknown')
         release_dir = self.download_dir / repo_name / tag_name
         release_dir.mkdir(parents=True, exist_ok=True)
-        
+
         download_results = []
-        
+
         for asset in release_data.get('assets', []):
             try:
                 # Check if asset matches patterns
                 if asset_patterns and not self._matches_patterns(asset['name'], asset_patterns):
                     logger.debug(f"Skipping asset {asset['name']} (doesn't match patterns)")
                     continue
-                
+
                 # Download the asset
                 result = self._download_single_asset(asset, release_dir, release_data)
                 download_results.append(result)
-                
+
             except Exception as e:
                 logger.error(f"Failed to download asset {asset.get('name', 'unknown')}: {e}")
                 download_results.append({
@@ -139,41 +150,41 @@ class GitHubDownloader:
                     'error': str(e),
                     'download_time': time.time()
                 })
-        
+
         logger.info(f"Downloaded {sum(1 for r in download_results if r['success'])} of "
                    f"{len(download_results)} assets for {repo_name}:{tag_name}")
-        
+
         return download_results
-    
-    def _download_single_asset(self, asset: Dict[str, Any], release_dir: Path, 
+
+    def _download_single_asset(self, asset: Dict[str, Any], release_dir: Path,
                               release_data: Dict[str, Any]) -> Dict[str, Any]:
         """
         Download a single asset with retry logic.
-        
+
         Args:
             asset: Asset metadata from GitHub API
             release_dir: Directory to save the asset
             release_data: Full release data for context
-            
+
         Returns:
             Download result metadata
         """
         asset_name = asset['name']
         download_url = asset['browser_download_url']
         file_path = release_dir / asset_name
-        
+
         logger.info(f"Downloading {asset_name} from {download_url}")
-        
+
         start_time = time.time()
-        
+
         try:
             # Download with retry logic
             success, error_msg = self._download_with_retry(download_url, file_path, asset)
-            
+
             if success:
                 # Verify download
                 verification_result = self.verify_download(file_path)
-                
+
                 # Prepare result metadata
                 result = {
                     'asset_name': asset_name,
@@ -190,7 +201,7 @@ class GitHubDownloader:
                         'published_at': release_data.get('published_at')
                     }
                 }
-                
+
                 logger.info(f"Successfully downloaded {asset_name} "
                            f"({result['file_size']} bytes in {result['download_time']:.1f}s)")
                 return result
@@ -202,7 +213,7 @@ class GitHubDownloader:
                     'download_time': time.time() - start_time,
                     'download_url': download_url
                 }
-                
+
         except Exception as e:
             logger.error(f"Unexpected error downloading {asset_name}: {e}")
             return {
@@ -211,33 +222,33 @@ class GitHubDownloader:
                 'error': f"Unexpected error: {str(e)}",
                 'download_time': time.time() - start_time
             }
-    
-    def _download_with_retry(self, url: str, file_path: Path, asset: Dict[str, Any], 
+
+    def _download_with_retry(self, url: str, file_path: Path, asset: Dict[str, Any],
                            max_retries: int = 3) -> Tuple[bool, Optional[str]]:
         """
         Download file with retry logic and streaming.
-        
+
         Args:
             url: Download URL
             file_path: Local file path to save to
             asset: Asset metadata for size checking
             max_retries: Maximum number of retry attempts
-            
+
         Returns:
             Tuple of (success, error_message)
         """
         last_error = None
-        
+
         for attempt in range(max_retries + 1):
             try:
                 # Use a temporary file for atomic downloads
                 with tempfile.NamedTemporaryFile(delete=False, dir=file_path.parent) as temp_file:
                     temp_path = Path(temp_file.name)
-                    
+
                     # Start the download
                     response = self.session.get(url, stream=True, timeout=self.timeout)
                     response.raise_for_status()
-                    
+
                     # Check content length if available
                     expected_size = asset.get('size')
                     content_length = response.headers.get('content-length')
@@ -246,18 +257,18 @@ class GitHubDownloader:
                         if expected_size and content_length != expected_size:
                             logger.warning(f"Content-Length ({content_length}) doesn't match "
                                          f"expected size ({expected_size})")
-                    
+
                     # Download in chunks with progress reporting
                     downloaded_size = 0
                     hash_sha256 = hashlib.sha256()
                     last_progress_time = time.time()
-                    
+
                     for chunk in response.iter_content(chunk_size=self.chunk_size):
                         if chunk:  # Filter out keep-alive chunks
                             temp_file.write(chunk)
                             hash_sha256.update(chunk)
                             downloaded_size += len(chunk)
-                            
+
                             # Report progress every 5 seconds
                             current_time = time.time()
                             if current_time - last_progress_time >= 5:
@@ -269,58 +280,58 @@ class GitHubDownloader:
                                 else:
                                     logger.info(f"Download progress: {mb_downloaded:.1f} MB downloaded")
                                 last_progress_time = current_time
-                    
+
                     temp_file.flush()
                     os.fsync(temp_file.fileno())
-                
+
                 # Verify size if expected
                 if expected_size and downloaded_size != expected_size:
                     temp_path.unlink()
                     raise ValueError(f"Downloaded size ({downloaded_size}) doesn't match "
                                    f"expected size ({expected_size})")
-                
+
                 # Atomically move to final location
                 shutil.move(str(temp_path), str(file_path))
-                
+
                 # Store checksum for verification
                 checksum_file = file_path.with_suffix(file_path.suffix + '.sha256')
                 with open(checksum_file, 'w') as f:
                     f.write(f"{hash_sha256.hexdigest()}  {file_path.name}\n")
-                
+
                 return True, None
-                
+
             except Exception as e:
                 last_error = str(e)
                 logger.warning(f"Download attempt {attempt + 1} failed: {e}")
-                
+
                 # Check if this is an SSL error
                 if 'CERTIFICATE_VERIFY_FAILED' in str(e) or 'SSLError' in str(e):
                     logger.error("SSL certificate verification failed. "
                                "Set GITHUB_SKIP_SSL_VERIFICATION=true to disable verification.")
-                
+
                 # Clean up temporary file if it exists
                 try:
                     if 'temp_path' in locals() and temp_path.exists():
                         temp_path.unlink()
                 except:
                     pass
-                
+
                 if attempt < max_retries:
                     # Exponential backoff
                     delay = 2 ** attempt
                     logger.info(f"Retrying in {delay} seconds...")
                     time.sleep(delay)
-        
+
         return False, f"Failed after {max_retries + 1} attempts. Last error: {last_error}"
-    
+
     def verify_download(self, file_path: Path, expected_checksum: Optional[str] = None) -> Dict[str, Any]:
         """
         Verify downloaded file integrity.
-        
+
         Args:
             file_path: Path to downloaded file
             expected_checksum: Optional expected SHA256 checksum
-            
+
         Returns:
             Verification result metadata
         """
@@ -330,16 +341,16 @@ class GitHubDownloader:
                 'error': 'File does not exist',
                 'file_path': str(file_path)
             }
-        
+
         try:
             # Calculate SHA256 checksum
             hash_sha256 = hashlib.sha256()
             with open(file_path, 'rb') as f:
                 for chunk in iter(lambda: f.read(self.chunk_size), b""):
                     hash_sha256.update(chunk)
-            
+
             calculated_checksum = hash_sha256.hexdigest()
-            
+
             # Check if we have a stored checksum file
             checksum_file = file_path.with_suffix(file_path.suffix + '.sha256')
             stored_checksum = None
@@ -348,13 +359,13 @@ class GitHubDownloader:
                     line = f.readline().strip()
                     if line:
                         stored_checksum = line.split()[0]
-            
+
             # Verify against expected or stored checksum
             checksum_to_verify = expected_checksum or stored_checksum
             checksum_match = None
             if checksum_to_verify:
                 checksum_match = calculated_checksum.lower() == checksum_to_verify.lower()
-            
+
             result = {
                 'verified': True,
                 'file_path': str(file_path),
@@ -363,60 +374,60 @@ class GitHubDownloader:
                 'checksum_match': checksum_match,
                 'expected_checksum': checksum_to_verify
             }
-            
+
             if checksum_match is False:
                 result['error'] = 'Checksum mismatch'
                 logger.error(f"Checksum mismatch for {file_path}: "
                            f"calculated={calculated_checksum}, expected={checksum_to_verify}")
-            
+
             return result
-            
+
         except Exception as e:
             return {
                 'verified': False,
                 'error': str(e),
                 'file_path': str(file_path)
             }
-    
+
     def _matches_patterns(self, filename: str, patterns: List[str]) -> bool:
         """
         Check if filename matches any of the given patterns.
-        
+
         Args:
             filename: Name of the file to check
             patterns: List of patterns (supports * wildcards)
-            
+
         Returns:
             True if filename matches any pattern
         """
         import fnmatch
-        
+
         filename_lower = filename.lower()
         matched = False
-        
+
         # First check inclusion patterns
         for pattern in patterns:
             if not pattern.startswith('!'):
                 if fnmatch.fnmatch(filename_lower, pattern.lower()):
                     matched = True
                     break
-        
+
         # If no inclusion pattern matched, return False
         if not matched:
             return False
-        
+
         # Now check exclusion patterns
         for pattern in patterns:
             if pattern.startswith('!'):
                 if fnmatch.fnmatch(filename_lower, pattern[1:].lower()):
                     return False
-        
+
         return True
-    
+
     def get_download_stats(self) -> Dict[str, Any]:
         """
         Get statistics about downloaded files.
-        
+
         Returns:
             Statistics about the download directory
         """
@@ -426,11 +437,11 @@ class GitHubDownloader:
                 'total_size': 0,
                 'repositories': 0
             }
-        
+
         total_files = 0
         total_size = 0
         repositories = set()
-        
+
         for repo_dir in self.download_dir.iterdir():
             if repo_dir.is_dir():
                 repositories.add(repo_dir.name)
@@ -440,7 +451,7 @@ class GitHubDownloader:
                             if file_path.is_file() and not file_path.name.endswith('.sha256'):
                                 total_files += 1
                                 total_size += file_path.stat().st_size
-        
+
         return {
             'total_files': total_files,
             'total_size': total_size,
@@ -448,31 +459,31 @@ class GitHubDownloader:
             'repositories': len(repositories),
             'download_dir': str(self.download_dir)
         }
-    
+
     def cleanup_old_downloads(self, keep_versions: int = 5) -> Dict[str, Any]:
         """
         Clean up old downloaded versions to save space.
-        
+
         Args:
             keep_versions: Number of recent versions to keep per repository
-            
+
         Returns:
             Cleanup statistics
         """
         if not self.download_dir.exists():
             return {'cleaned_files': 0, 'freed_space': 0}
-        
+
         cleaned_files = 0
         freed_space = 0
-        
+
         for repo_dir in self.download_dir.iterdir():
             if not repo_dir.is_dir():
                 continue
-            
+
             # Get all version directories sorted by modification time
             version_dirs = [d for d in repo_dir.iterdir() if d.is_dir()]
             version_dirs.sort(key=lambda d: d.stat().st_mtime, reverse=True)
-            
+
             # Remove old versions
             for old_dir in version_dirs[keep_versions:]:
                 try:
@@ -480,50 +491,50 @@ class GitHubDownloader:
                         if file_path.is_file():
                             freed_space += file_path.stat().st_size
                             cleaned_files += 1
-                    
+
                     shutil.rmtree(old_dir)
                     logger.info(f"Cleaned up old version: {old_dir}")
-                    
+
                 except Exception as e:
                     logger.error(f"Error cleaning up {old_dir}: {e}")
-        
+
         return {
             'cleaned_files': cleaned_files,
             'freed_space': freed_space,
             'freed_space_mb': round(freed_space / (1024 * 1024), 2)
         }
-    
-    def _should_download_source(self, release_data: Dict[str, Any], 
-                               asset_patterns: Optional[List[str]], 
+
+    def _should_download_source(self, release_data: Dict[str, Any],
+                               asset_patterns: Optional[List[str]],
                                asset_results: List[Dict[str, Any]],
                                source_config: Dict[str, Any]) -> bool:
         """
         Determine if source code archives should be downloaded.
-        
+
         Args:
             release_data: Release data from GitHub API
             asset_patterns: Asset filtering patterns
             asset_results: Results from asset downloads
             source_config: Source archive configuration
-            
+
         Returns:
             True if source code should be downloaded
         """
         # Check if fallback_only is disabled (always download source)
         if not source_config.get('fallback_only', True):
             return True
-        
+
         # If no asset patterns specified, download source when no assets were found
         if not asset_patterns:
             return len([r for r in asset_results if r['success']]) == 0
-        
+
         # Check if patterns explicitly request source archives (only exact matches for source-specific terms)
         explicit_source_patterns = ['source', 'tarball', 'zipball']
         for pattern in asset_patterns:
             pattern_lower = pattern.lower()
             if any(sp == pattern_lower for sp in explicit_source_patterns):
                 return True
-        
+
         # Check if patterns include manifest/config file types that might not have traditional assets
         manifest_patterns = ['*.yaml', '*.yml', '*.json', '*.xml', '*.toml']
         for pattern in asset_patterns:
@@ -531,45 +542,45 @@ class GitHubDownloader:
             if any(mp in pattern_lower for mp in manifest_patterns):
                 # If looking for manifests but no assets matched, try source
                 return len([r for r in asset_results if r['success']]) == 0
-        
+
         # If assets were successfully downloaded, don't download source unless explicitly requested
         successful_assets = [r for r in asset_results if r['success']]
         if successful_assets:
             return False
-        
+
         # No successful asset downloads, fall back to source
         return True
-    
-    def download_source_archives(self, release_data: Dict[str, Any], 
+
+    def download_source_archives(self, release_data: Dict[str, Any],
                                 asset_patterns: Optional[List[str]] = None,
                                 source_config: Optional[Dict[str, Any]] = None) -> List[Dict[str, Any]]:
         """
         Download source code archives (tarball and/or zipball) from GitHub release.
-        
+
         Args:
             release_data: Release data from GitHub API or monitor
             asset_patterns: Optional list of patterns to filter archives
             source_config: Optional source archive configuration
-            
+
         Returns:
             List of download results with metadata
         """
         download_results = []
-        
+
         # Default source configuration
         if source_config is None:
             source_config = {'enabled': True, 'prefer': 'tarball', 'fallback_only': True}
-        
+
         # Create release-specific directory
         repo_name = release_data.get('repository', 'unknown').replace('/', '_')
         tag_name = release_data.get('tag_name', 'unknown')
         release_dir = self.download_dir / repo_name / tag_name
         release_dir.mkdir(parents=True, exist_ok=True)
-        
+
         # Prepare source archive info based on preference
         source_archives = []
         prefer = source_config.get('prefer', 'tarball').lower()
-        
+
         if prefer == 'both':
             # Download both tarball and zipball
             if release_data.get('tarball_url'):
@@ -580,7 +591,7 @@ class GitHubDownloader:
                 })
             if release_data.get('zipball_url'):
                 source_archives.append({
-                    'name': f'{repo_name}-{tag_name}.zip', 
+                    'name': f'{repo_name}-{tag_name}.zip',
                     'url': release_data['zipball_url'],
                     'type': 'zipball'
                 })
@@ -588,7 +599,7 @@ class GitHubDownloader:
             # Prefer zipball, fallback to tarball
             if release_data.get('zipball_url'):
                 source_archives.append({
-                    'name': f'{repo_name}-{tag_name}.zip', 
+                    'name': f'{repo_name}-{tag_name}.zip',
                     'url': release_data['zipball_url'],
                     'type': 'zipball'
                 })
@@ -608,11 +619,11 @@ class GitHubDownloader:
                 })
             elif release_data.get('zipball_url'):
                 source_archives.append({
-                    'name': f'{repo_name}-{tag_name}.zip', 
+                    'name': f'{repo_name}-{tag_name}.zip',
                     'url': release_data['zipball_url'],
                     'type': 'zipball'
                 })
-        
+
         for archive in source_archives:
             try:
                 # Source archives are controlled by source_config settings (prefer, fallback_only, etc.)
@@ -624,30 +635,30 @@ class GitHubDownloader:
                     # Check for explicit source type filters
                     has_tarball_filter = 'tarball' in [p.lower() for p in asset_patterns]
                     has_zipball_filter = 'zipball' in [p.lower() for p in asset_patterns]
-                    
+
                     # If specific source type filters are present, only download matching types
                     if has_tarball_filter or has_zipball_filter:
                         if archive['type'] == 'tarball' and not has_tarball_filter:
                             should_skip_archive = True
                         elif archive['type'] == 'zipball' and not has_zipball_filter:
                             should_skip_archive = True
-                
+
                 if should_skip_archive:
                     logger.debug(f"Skipping source archive {archive['name']} (type {archive['type']} not in explicit filters)")
                     continue
-                
+
                 # Create a pseudo-asset for the source archive
                 pseudo_asset = {
                     'name': archive['name'],
                     'browser_download_url': archive['url'],
                     'size': None  # GitHub doesn't provide size for source archives
                 }
-                
+
                 # Download the source archive
                 result = self._download_single_asset(pseudo_asset, release_dir, release_data)
                 result['source_type'] = archive['type']  # Mark as source archive
                 download_results.append(result)
-                
+
             except Exception as e:
                 logger.error(f"Failed to download source archive {archive['name']}: {e}")
                 download_results.append({
@@ -657,9 +668,9 @@ class GitHubDownloader:
                     'error': str(e),
                     'download_time': time.time()
                 })
-        
+
         if download_results:
             successful = sum(1 for r in download_results if r['success'])
             logger.info(f"Downloaded {successful} of {len(download_results)} source archives for {repo_name}:{tag_name}")
-        
+
         return download_results

--- a/test_proxy_ssl.py
+++ b/test_proxy_ssl.py
@@ -1,0 +1,90 @@
+#!/usr/bin/env python3
+"""
+Test script to verify proxy and SSL settings for GitHub downloads.
+"""
+
+import os
+import requests
+import urllib3
+
+# Test environment variables
+print("=== Environment Variables ===")
+print(f"HTTP_PROXY: {os.getenv('HTTP_PROXY', 'Not set')}")
+print(f"HTTPS_PROXY: {os.getenv('HTTPS_PROXY', 'Not set')}")
+print(f"NO_PROXY: {os.getenv('NO_PROXY', 'Not set')}")
+print(f"GITHUB_SKIP_SSL_VERIFICATION: {os.getenv('GITHUB_SKIP_SSL_VERIFICATION', 'Not set')}")
+print()
+
+# Create a session with proper configuration
+session = requests.Session()
+
+# Configure proxy settings
+proxy_settings = {}
+if os.getenv('HTTP_PROXY') or os.getenv('http_proxy'):
+    proxy_settings['http'] = os.getenv('HTTP_PROXY') or os.getenv('http_proxy')
+if os.getenv('HTTPS_PROXY') or os.getenv('https_proxy'):
+    proxy_settings['https'] = os.getenv('HTTPS_PROXY') or os.getenv('https_proxy')
+
+if proxy_settings:
+    session.proxies = proxy_settings
+    print(f"Configured proxy settings: {proxy_settings}")
+
+# Configure SSL verification
+skip_ssl_verification = os.environ.get('GITHUB_SKIP_SSL_VERIFICATION', 'false').lower() == 'true'
+if skip_ssl_verification:
+    print("SSL verification disabled")
+    session.verify = False
+    urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+else:
+    print("SSL verification enabled")
+
+print()
+
+# Test URLs
+test_urls = [
+    {
+        'name': 'GitHub API',
+        'url': 'https://api.github.com'
+    },
+    {
+        'name': 'GitHub Release (will redirect)',
+        'url': 'https://github.com/wavefrontHQ/observability-for-kubernetes/releases/download/v2.30.0/wavefront-operator.yaml'
+    }
+]
+
+print("=== Testing Connections ===")
+for test in test_urls:
+    print(f"\nTesting {test['name']}: {test['url']}")
+    try:
+        # Test with allow_redirects=False first to see the redirect
+        response = session.get(test['url'], allow_redirects=False, timeout=10)
+        print(f"  Initial response: {response.status_code}")
+        
+        if response.status_code in [301, 302, 303, 307, 308]:
+            redirect_url = response.headers.get('Location')
+            print(f"  Redirect to: {redirect_url}")
+            
+            # Follow the redirect
+            print(f"  Following redirect...")
+            final_response = session.get(redirect_url, timeout=10)
+            print(f"  Final response: {final_response.status_code}")
+            print(f"  Content type: {final_response.headers.get('content-type', 'Not specified')}")
+            print(f"  Content length: {final_response.headers.get('content-length', 'Not specified')} bytes")
+        else:
+            print(f"  Content type: {response.headers.get('content-type', 'Not specified')}")
+            
+    except requests.exceptions.SSLError as e:
+        print(f"  SSL Error: {str(e)}")
+        print(f"  This suggests SSL verification is still enabled for this domain")
+    except requests.exceptions.ProxyError as e:
+        print(f"  Proxy Error: {str(e)}")
+    except requests.exceptions.ConnectionError as e:
+        print(f"  Connection Error: {str(e)}")
+    except Exception as e:
+        print(f"  Error: {type(e).__name__}: {str(e)}")
+
+print("\n=== Recommendations ===")
+print("1. Ensure GITHUB_SKIP_SSL_VERIFICATION=true is set")
+print("2. Ensure HTTP_PROXY and HTTPS_PROXY are properly configured")
+print("3. Check if objects.githubusercontent.com needs to be in NO_PROXY")
+print("4. Consider using curl with -k flag as a workaround if Python requests fails")


### PR DESCRIPTION
1. Added proxy configuration to github_downloader.py (lines 56-65) - The downloader now respects HTTP_PROXY and HTTPS_PROXY environment variables, matching the behavior in github_monitor.py.
2. SSL verification is already properly disabled when GITHUB_SKIP_SSL_VERIFICATION=true is set.
3. Created a test script (test_proxy_ssl.py) that you can run to verify your proxy and SSL settings are working correctly.