### PR TITLE
Add username/password fallback authentication for Artifactory

### DIFF
--- a/ci/pipeline-artifactory.yml
+++ b/ci/pipeline-artifactory.yml
@@ -60,6 +60,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
       - task: upload-monitor-output
@@ -68,6 +70,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
     #   - task: prepare-email-notification
@@ -101,6 +105,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
       - task: download-releases
@@ -117,11 +123,13 @@ jobs:
           CLEANUP_OLD_VERSIONS: ((download_cleanup_old_versions))
           KEEP_VERSIONS: ((download_keep_versions))
           REPOSITORY_OVERRIDES: ((download_repository_overrides))
-          
+
           # Artifactory configuration for version database
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
           # Force re-download for testing (comment out in production)
@@ -134,6 +142,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
   # Clear version database to force re-downloads
@@ -147,6 +157,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
   - name: reset-version-database
@@ -159,6 +171,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
   # Parameterized job to force download any repository for testing
@@ -173,6 +187,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
           REPO_NAME: ((force_download_repo))  # Parameter: e.g., "etcd-io/etcd"
 
@@ -186,6 +202,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
       - task: upload-monitor-output
@@ -194,6 +212,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
       - task: fetch-monitor-output
@@ -202,6 +222,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
       - task: download-releases
@@ -221,6 +243,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
       - task: upload-to-artifactory
@@ -229,6 +253,8 @@ jobs:
           ARTIFACTORY_URL: ((artifactory_url))
           ARTIFACTORY_REPOSITORY: ((artifactory_repository))
           ARTIFACTORY_API_KEY: ((artifactory_api_key))
+          ARTIFACTORY_USERNAME: ((artifactory_username))
+          ARTIFACTORY_PASSWORD: ((artifactory_password))
           ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
 # Resource types (if not available in your Concourse deployment)

--- a/ci/tasks/clear-repo-from-db/task.yml
+++ b/ci/tasks/clear-repo-from-db/task.yml
@@ -15,6 +15,8 @@ params:
   ARTIFACTORY_URL: ((artifactory_url))
   ARTIFACTORY_REPOSITORY: ((artifactory_repository))
   ARTIFACTORY_API_KEY: ((artifactory_api_key))
+  ARTIFACTORY_USERNAME: ((artifactory_username))
+  ARTIFACTORY_PASSWORD: ((artifactory_password))
   ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
   REPO_NAME: ((force_download_repo))  # Parameter: e.g., "etcd-io/etcd"
 

--- a/ci/tasks/clear-version-db/task.yml
+++ b/ci/tasks/clear-version-db/task.yml
@@ -15,6 +15,8 @@ params:
   ARTIFACTORY_URL: ((artifactory_url))
   ARTIFACTORY_REPOSITORY: ((artifactory_repository))
   ARTIFACTORY_API_KEY: ((artifactory_api_key))
+  ARTIFACTORY_USERNAME: ((artifactory_username))
+  ARTIFACTORY_PASSWORD: ((artifactory_password))
   ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
 run:

--- a/ci/tasks/fetch-monitor-output/task.yml
+++ b/ci/tasks/fetch-monitor-output/task.yml
@@ -19,6 +19,8 @@ params:
   ARTIFACTORY_URL: ((artifactory_url))
   ARTIFACTORY_REPOSITORY: ((artifactory_repository))
   ARTIFACTORY_API_KEY: ((artifactory_api_key))
+  ARTIFACTORY_USERNAME: ((artifactory_username))
+  ARTIFACTORY_PASSWORD: ((artifactory_password))
   ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
 run:

--- a/ci/tasks/show-version-db/task.yml
+++ b/ci/tasks/show-version-db/task.yml
@@ -15,6 +15,8 @@ params:
   ARTIFACTORY_URL: ((artifactory_url))
   ARTIFACTORY_REPOSITORY: ((artifactory_repository))
   ARTIFACTORY_API_KEY: ((artifactory_api_key))
+  ARTIFACTORY_USERNAME: ((artifactory_username))
+  ARTIFACTORY_PASSWORD: ((artifactory_password))
   ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
 run:

--- a/ci/tasks/upload-monitor-output/task.yml
+++ b/ci/tasks/upload-monitor-output/task.yml
@@ -17,6 +17,8 @@ params:
   ARTIFACTORY_URL: ((artifactory_url))
   ARTIFACTORY_REPOSITORY: ((artifactory_repository))
   ARTIFACTORY_API_KEY: ((artifactory_api_key))
+  ARTIFACTORY_USERNAME: ((artifactory_username))
+  ARTIFACTORY_PASSWORD: ((artifactory_password))
   ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
 run:

--- a/ci/tasks/upload-to-artifactory/task.yml
+++ b/ci/tasks/upload-to-artifactory/task.yml
@@ -17,6 +17,8 @@ params:
   ARTIFACTORY_URL: ((artifactory_url))
   ARTIFACTORY_REPOSITORY: ((artifactory_repository))
   ARTIFACTORY_API_KEY: ((artifactory_api_key))
+  ARTIFACTORY_USERNAME: ((artifactory_username))
+  ARTIFACTORY_PASSWORD: ((artifactory_password))
   ARTIFACTORY_SKIP_SSL_VERIFICATION: ((artifactory_skip_ssl_verification))
 
 run:

--- a/scripts/show-version-db-artifactory.py
+++ b/scripts/show-version-db-artifactory.py
@@ -27,9 +27,24 @@ def main():
         print("ERROR: ARTIFACTORY_REPOSITORY environment variable not set")
         sys.exit(1)
 
+    # Authentication - prefer API key over username/password
     api_key = os.environ.get('ARTIFACTORY_API_KEY')
-    if not api_key:
-        print("ERROR: ARTIFACTORY_API_KEY environment variable not set")
+    username = os.environ.get('ARTIFACTORY_USERNAME')
+    password = os.environ.get('ARTIFACTORY_PASSWORD')
+
+    headers = {}
+    auth = None
+
+    if api_key:
+        headers['Authorization'] = f'Bearer {api_key}'
+        print("Using API key authentication")
+    elif username and password:
+        from requests.auth import HTTPBasicAuth
+        auth = HTTPBasicAuth(username, password)
+        print(f"Using username/password authentication for user: {username}")
+    else:
+        print("ERROR: No authentication credentials found.")
+        print("Set ARTIFACTORY_API_KEY or ARTIFACTORY_USERNAME/ARTIFACTORY_PASSWORD")
         sys.exit(1)
 
     # SSL verification
@@ -43,11 +58,10 @@ def main():
 
     # Download version database
     url = f"{artifactory_url.rstrip('/')}/{repository}/release-monitor/version_db.json"
-    headers = {'Authorization': f'Bearer {api_key}'}
 
     try:
         print(f"Fetching version database from: {url}")
-        response = requests.get(url, headers=headers, verify=verify_ssl)
+        response = requests.get(url, headers=headers, auth=auth, verify=verify_ssl)
 
         if response.status_code == 404:
             print("No version database found in Artifactory")


### PR DESCRIPTION
Add username/password fallback authentication for Artifactory integration

## Summary
- Added username/password authentication fallback for all Artifactory scripts and tasks
- Maintains API key as primary authentication method with HTTPBasicAuth as fallback
- Provides enterprise compatibility for environments requiring username/password auth

## Changes Made

### Core Scripts Enhanced
- scripts/fetch-monitor-output.py - Fixed syntax errors and added proper auth fallback
- scripts/show-version-db-artifactory.py - Added HTTPBasicAuth fallback support
- scripts/clear-version-db-artifactory.py - Added username/password authentication
- scripts/clear-version-entry-artifactory.py - Updated both GET and PUT requests
- scripts/clean-artifactory-repository.py - Refactored all functions for dual auth support

### Pipeline Integration
- Updated all 6 Artifactory task.yml files with ARTIFACTORY_USERNAME/PASSWORD params
- Updated ci/pipeline-artifactory.yml to pass username/password to all tasks
- Maintained backward compatibility with existing API key authentication

### Authentication Logic
- Consistent pattern across all scripts: API key primary, username/password fallback
- Clear error messages when no authentication credentials provided
- User feedback indicating which authentication method is being used

## Benefits
- Zero breaking changes - existing API key workflows continue unchanged
- Enterprise compatibility for corporate authentication systems
- Flexible deployment options based on available credential types
- Consistent authentication patterns across all Artifactory components